### PR TITLE
secureclip: Fix lastClip race with a mutex

### DIFF
--- a/secureclip/secureclip.go
+++ b/secureclip/secureclip.go
@@ -1,15 +1,30 @@
 package secureclip
 
 import (
+	"sync"
 	"time"
 
 	"github.com/atotto/clipboard"
 )
 
 var (
-	lastClip    = time.Now()
-	clipTimeout = time.Second * 30
+	lastClip     = time.Now()
+	lastClipLock sync.Mutex
+	clipTimeout  = time.Second * 30
 )
+
+func getLastClip() time.Time {
+	lastClipLock.Lock()
+	t := lastClip
+	lastClipLock.Unlock()
+	return t
+}
+
+func setLastClip(t time.Time) {
+	lastClipLock.Lock()
+	lastClip = t
+	lastClipLock.Unlock()
+}
 
 // Clip copies the passphrase given by `passphrase` to the clipboard. The
 // clipboard will be cleared 30 seconds after the last `Clip` call.
@@ -18,10 +33,10 @@ func Clip(passphrase string) error {
 	if err != nil {
 		return err
 	}
-	lastClip = time.Now()
+	setLastClip(time.Now())
 	go func() {
 		time.Sleep(clipTimeout)
-		if time.Since(lastClip) > clipTimeout {
+		if time.Since(getLastClip()) > clipTimeout {
 			clipboard.WriteAll("")
 		}
 	}()


### PR DESCRIPTION
Currently lastClip is accessed by multiple go-routines without locking, which is a data race.

This patch fixes the data race.