### PR TITLE
Vault patches

### DIFF
--- a/cmd_test.go
+++ b/cmd_test.go
@@ -329,7 +329,8 @@ func TestSearchCommand(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res != "testloc\nloc2\n" {
+	// Both orders are fine.
+	if res != "testloc\nloc2\n" && res != "loc2\ntestloc\n" {
 		t.Log(res)
 		t.Fatal("search command did not find credentials")
 	}

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -96,19 +96,13 @@ func New(passphrase string) (*Vault, error) {
 // vault is re-encrypted, ensuring nonces are unique and not reused across
 // sessions.
 func Open(filename string, passphrase string) (*Vault, error) {
-	f, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	var encryptedData bytes.Buffer
-	_, err = io.Copy(&encryptedData, f)
+	bs, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
 	var nonce [24]byte
-	copy(nonce[:], encryptedData.Bytes()[:24])
+	copy(nonce[:], bs[:24])
 
 	key, err := scrypt.Key([]byte(passphrase), nonce[:], scryptN, scryptR, scryptP, keyLen)
 	if err != nil {
@@ -119,7 +113,7 @@ func Open(filename string, passphrase string) (*Vault, error) {
 	copy(secret[:], key)
 
 	vault := &Vault{
-		data:   encryptedData.Bytes(),
+		data:   bs,
 		nonce:  nonce,
 		secret: secret,
 	}

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -3,13 +3,13 @@ package vault
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/gob"
 	"errors"
 	"io"
 	"io/ioutil"
 	"os"
 	"path"
 
-	"encoding/gob"
 	"github.com/NebulousLabs/entropy-mnemonics"
 	"golang.org/x/crypto/nacl/secretbox"
 	"golang.org/x/crypto/scrypt"

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -236,8 +236,9 @@ func (v *Vault) Save(filename string) error {
 	if err != nil {
 		return err
 	}
+	defer tempfile.Close()
 
-	_, err = io.Copy(tempfile, bytes.NewBuffer(v.data))
+	_, err = tempfile.Write(v.data)
 	if err != nil {
 		return err
 	}

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -243,6 +243,11 @@ func (v *Vault) Save(filename string) error {
 		return err
 	}
 
+	err = tempfile.Sync()
+	if err != nil {
+		return err
+	}
+
 	err = os.Rename(tempfile.Name(), filename)
 	if err != nil {
 		return err


### PR DESCRIPTION
Patches to vault:
+ In the import list encoding/gob belongs to the stdlib imports
+ Simplify Open and avoid superfluous io.Copy and properly Close file (by using ioutil)
+ Simplify Save and properly Close file
+ Sync temporary file before rename in Save

Additionally fix TestSearchCommand which depended on unstable map iteration order.
