### PR TITLE
Ability to clip metatags

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -62,7 +62,7 @@ var (
 		return repl.Command{
 			Name:   "clip",
 			Action: clip(v),
-			Usage:  "clip [location] [metatag]: copy the password at location to the clipboard. metatag optional",
+			Usage:  "clip [location] [meta name]: copy the password at location to the clipboard. meta name optional",
 		}
 	}
 

--- a/cmd.go
+++ b/cmd.go
@@ -210,6 +210,7 @@ func clip(v *vault.Vault) repl.ActionFunc {
 		}
 
 		toClip := cred.Password
+		clipType := "password"
 		if len(args) > 1 {
 			meta := args[1]
 			metaval, exists := cred.Meta[meta]
@@ -217,13 +218,14 @@ func clip(v *vault.Vault) repl.ActionFunc {
 				return "", fmt.Errorf("%v metadata tag not found.", meta)
 			}
 			toClip = metaval
+			clipType = meta
 		}
 
 		err = secureclip.Clip(toClip)
 		if err != nil {
 			return "", err
 		}
-		return fmt.Sprintf("%v copied to clipboard, will clear in 30 seconds\n", location), nil
+		return fmt.Sprintf("%v copied %v to clipboard, will clear in 30 seconds\n", location, clipType), nil
 	}
 }
 

--- a/cmd.go
+++ b/cmd.go
@@ -62,7 +62,7 @@ var (
 		return repl.Command{
 			Name:   "clip",
 			Action: clip(v),
-			Usage:  "clip [location]: copy the password at location to the clipboard.",
+			Usage:  "clip [location] [metatag]: copy the password at location to the clipboard. metatag optional",
 		}
 	}
 
@@ -199,8 +199,8 @@ func search(v *vault.Vault) repl.ActionFunc {
 
 func clip(v *vault.Vault) repl.ActionFunc {
 	return func(args []string) (string, error) {
-		if len(args) != 1 {
-			return "", fmt.Errorf("clip requires 1 argument. See help for usage.")
+		if len(args) < 1 {
+			return "", fmt.Errorf("clip requires at least 1 argument. See help for usage.")
 		}
 
 		location := args[0]
@@ -208,7 +208,19 @@ func clip(v *vault.Vault) repl.ActionFunc {
 		if err != nil {
 			return "", err
 		}
-		err = secureclip.Clip(cred.Password)
+
+		var toClip string
+		if len(args) > 1 {
+			meta := args[1]
+			if val, ok := cred.Meta[meta]; ok {
+				toClip = val
+			} else {
+				return "", fmt.Errorf("%v metadata tag not found.")
+			}
+		} else {
+			toClip = cred.Password
+		}
+		err = secureclip.Clip(toClip)
 		if err != nil {
 			return "", err
 		}

--- a/cmd.go
+++ b/cmd.go
@@ -209,17 +209,16 @@ func clip(v *vault.Vault) repl.ActionFunc {
 			return "", err
 		}
 
-		var toClip string
+		toClip := cred.Password
 		if len(args) > 1 {
 			meta := args[1]
-			if val, ok := cred.Meta[meta]; ok {
-				toClip = val
-			} else {
-				return "", fmt.Errorf("%v metadata tag not found.")
+			metaval, exists := cred.Meta[meta]
+			if !exists {
+				return "", fmt.Errorf("%v metadata tag not found.", meta)
 			}
-		} else {
-			toClip = cred.Password
+			toClip = metaval
 		}
+
 		err = secureclip.Clip(toClip)
 		if err != nil {
 			return "", err

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -213,7 +213,7 @@ func TestClipCommand(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res != "testlocation copied to clipboard, will clear in 30 seconds\n" {
+	if res != "testlocation copied password to clipboard, will clear in 30 seconds\n" {
 		t.Fatal("clip command should return success string")
 	}
 
@@ -234,7 +234,7 @@ func TestClipCommand(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res != "testlocation copied to clipboard, will clear in 30 seconds\n" {
+	if res != "testlocation copied test to clipboard, will clear in 30 seconds\n" {
 		t.Fatal("clip command should return success string")
 	}
 

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -224,6 +224,27 @@ func TestClipCommand(t *testing.T) {
 	if clipcontents != "testpass" {
 		t.Fatal("clip command did not copy the passphrase into the clipboard")
 	}
+
+	err = v.AddMeta("testlocation", "test", "test1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err = clipcmd([]string{"testlocation", "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != "testlocation copied to clipboard, will clear in 30 seconds\n" {
+		t.Fatal("clip command should return success string")
+	}
+
+	clipcontents, err = clipboard.ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if clipcontents != "test1" {
+		t.Fatal("clip command did not copy the metadata into the clipboard")
+	}
 }
 
 func TestAddMetaCommand(t *testing.T) {


### PR DESCRIPTION
`clip [location] [metatag]`

If `metatag` isn't present it defaults to the password